### PR TITLE
Fix socket issue python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ docs/_build/
 
 # pyenv
 .python-version
+
+# py.test
+pytest-local.py

--- a/plx_gpib_ethernet/plx_gpib_ethernet.py
+++ b/plx_gpib_ethernet/plx_gpib_ethernet.py
@@ -35,10 +35,12 @@ class PrologixGPIBEthernet:
         return self.read(buffer_size)
 
     def _send(self, value):
-        self.socket.send('%s\n' % value)
+        encoded_value = ('%s\n' % value).encode('ascii')
+        self.socket.send(encoded_value)
 
     def _recv(self, byte_num):
-        return self.socket.recv(byte_num)
+        value = self.socket.recv(byte_num)
+        return value.decode('ascii')
 
     def _setup(self):
         # set device to CONTROLLER mode

--- a/tests/support/mock_socket.py
+++ b/tests/support/mock_socket.py
@@ -19,7 +19,7 @@ class MockSocket:
 
     def send(self, value):
         assert type(value) == bytes
-        self.out_buffer.append(value)
+        self.out_buffer.append(value.decode('ascii'))
 
     def recv(self, byte_num):
         value = self.in_buffer.pop()

--- a/tests/support/mock_socket.py
+++ b/tests/support/mock_socket.py
@@ -18,7 +18,9 @@ class MockSocket:
         self.closed = True
 
     def send(self, value):
+        assert type(value) == bytes
         self.out_buffer.append(value)
 
     def recv(self, byte_num):
-        return self.in_buffer.pop()
+        value = self.in_buffer.pop()
+        return value.encode('ascii')


### PR DESCRIPTION
Fix socket issue on Python 3, specifically:

> socket.send and socket.recv use bytes instead of str type in Python 3
