### PR TITLE
Add more recent python versions to travis ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 install: "pip install -r requirements/dev.txt"
 script: "pip install -e . && py.test -q --cov=plx_gpib_ethernet tests/"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,5 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
 -r common.txt
-pytest==2.9.2
-pytest-cov==2.3.1
+pytest==6.1.2
+pytest-cov==2.10.1


### PR DESCRIPTION
Add continous integration tests for Python
- 3.7,
- 3.8, and
- 3.9