### PR TITLE
Add recent python versions to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,6 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,31 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
+      
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"      
+
+    - PYTHON: "C:\\Python38"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64" 
+      
+    - PYTHON: "C:\\Python39"
+      PYTHON_VERSION: "3.9.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python39-x64"
+      PYTHON_VERSION: "3.9.x"
+      PYTHON_ARCH: "64" 
+      
 install:
   - ECHO "Filesystem root:"
   - ps: "ls \"C:/\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,14 +40,6 @@ environment:
       PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "64" 
       
-    - PYTHON: "C:\\Python39"
-      PYTHON_VERSION: "3.9.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python39-x64"
-      PYTHON_VERSION: "3.9.x"
-      PYTHON_ARCH: "64" 
-      
 install:
   - ECHO "Filesystem root:"
   - ps: "ls \"C:/\""


### PR DESCRIPTION
Add continous integration tests for Python
- 3.7 and
- 3.8