### PR TITLE
Fix: Check timeout argument for valid range

### DIFF
--- a/plx_gpib_ethernet/plx_gpib_ethernet.py
+++ b/plx_gpib_ethernet/plx_gpib_ethernet.py
@@ -4,11 +4,14 @@ import socket
 class PrologixGPIBEthernet:
     PORT = 1234
 
-    def __init__(self, host, timeout=1.):
-        self.host = host
+    def __init__(self, host, timeout=1):
+        # see user manual for details on accepted timeout values
+        # https://prologix.biz/downloads/PrologixGpibEthernetManual.pdf#page=13
+        if timeout < 1e-3 or timeout > 3:
+            raise ValueError('Timeout must be >= 1e-3 (1ms) and <= 3 (3s)')
 
-        # Prologix's read_tmo_ms only accepts timeouts <=3000ms
-        self.timeout = min(timeout, 3.)
+        self.host = host
+        self.timeout = timeout
 
         self.socket = socket.socket(socket.AF_INET,
                                     socket.SOCK_STREAM,

--- a/plx_gpib_ethernet/plx_gpib_ethernet.py
+++ b/plx_gpib_ethernet/plx_gpib_ethernet.py
@@ -4,9 +4,11 @@ import socket
 class PrologixGPIBEthernet:
     PORT = 1234
 
-    def __init__(self, host, timeout=1):
+    def __init__(self, host, timeout=1.):
         self.host = host
-        self.timeout = timeout
+
+        # Prologix's read_tmo_ms only accepts timeouts <=3000ms
+        self.timeout = min(timeout, 3.)
 
         self.socket = socket.socket(socket.AF_INET,
                                     socket.SOCK_STREAM,

--- a/tests/plx_gpib_ethernet_test.py
+++ b/tests/plx_gpib_ethernet_test.py
@@ -1,10 +1,10 @@
 from plx_gpib_ethernet import PrologixGPIBEthernet
-from pytest import fixture
+import pytest
 from support import MockSocket
 from random import randint
 
 
-@fixture
+@pytest.fixture
 def plx_with_mock_socket():
     plx = PrologixGPIBEthernet('example.com')
     plx.socket = MockSocket('example.com', 1234)
@@ -36,6 +36,12 @@ def test_it_uses_custom_timeout():
     plx = PrologixGPIBEthernet('example.com', timeout=0.5)
 
     assert plx.timeout == 0.5
+
+
+def test_it_raises_value_error_for_invalid_timeout():
+    for invalid_timeout in (1e-3 - 1e-12, 3 + 1e-12):
+        with pytest.raises(ValueError):
+            PrologixGPIBEthernet('example.com', timeout=invalid_timeout)
 
 
 # .connect


### PR DESCRIPTION
See https://github.com/nelsond/prologix-gpib-ethernet/pull/7.