### PR TITLE
adding set_timeout method for dynamically setting timeout

### DIFF
--- a/plx_gpib_ethernet/plx_gpib_ethernet.py
+++ b/plx_gpib_ethernet/plx_gpib_ethernet.py
@@ -5,18 +5,12 @@ class PrologixGPIBEthernet:
     PORT = 1234
 
     def __init__(self, host, timeout=1):
-        # see user manual for details on accepted timeout values
-        # https://prologix.biz/downloads/PrologixGpibEthernetManual.pdf#page=13
-        if timeout < 1e-3 or timeout > 3:
-            raise ValueError('Timeout must be >= 1e-3 (1ms) and <= 3 (3s)')
-
         self.host = host
-        self.timeout = timeout
-
         self.socket = socket.socket(socket.AF_INET,
                                     socket.SOCK_STREAM,
                                     socket.IPPROTO_TCP)
-        self.socket.settimeout(self.timeout)
+        self.timeout = 0
+        self.set_timeout(timeout)
 
     def connect(self):
         self.socket.connect((self.host, self.PORT))
@@ -39,6 +33,14 @@ class PrologixGPIBEthernet:
     def query(self, cmd, buffer_size=1024*1024):
         self.write(cmd)
         return self.read(buffer_size)
+
+    def set_timeout(self, timeout):
+        # see user manual for details on accepted timeout values
+        # https://prologix.biz/downloads/PrologixGpibEthernetManual.pdf#page=13
+        if timeout < 1e-3 or timeout > 3:
+            raise ValueError('Timeout must be >= 1e-3 (1ms) and <= 3 (3s)')
+        self.timeout = timeout
+        self.socket.settimeout(self.timeout)
 
     def _send(self, value):
         encoded_value = ('%s\n' % value).encode('ascii')

--- a/plx_gpib_ethernet/plx_gpib_ethernet.py
+++ b/plx_gpib_ethernet/plx_gpib_ethernet.py
@@ -39,6 +39,7 @@ class PrologixGPIBEthernet:
         # https://prologix.biz/downloads/PrologixGpibEthernetManual.pdf#page=13
         if timeout < 1e-3 or timeout > 3:
             raise ValueError('Timeout must be >= 1e-3 (1ms) and <= 3 (3s)')
+
         self.timeout = timeout
         self.socket.settimeout(self.timeout)
 

--- a/tests/plx_gpib_ethernet_test.py
+++ b/tests/plx_gpib_ethernet_test.py
@@ -140,3 +140,12 @@ def test_it_reads_gpib_query_response(plx_with_mock_socket):
     result = plx.query('*IDN?')
 
     assert result == response
+
+
+# .set_timeout
+def test_it_sets_custom_timeout(plx_with_mock_socket):
+    plx, _ = plx_with_mock_socket
+    timeout = 2 + (randint(0, 10) / 10)
+    plx.set_timeout(timeout)
+
+    assert plx.timeout == 2

--- a/tests/plx_gpib_ethernet_test.py
+++ b/tests/plx_gpib_ethernet_test.py
@@ -148,4 +148,4 @@ def test_it_sets_custom_timeout(plx_with_mock_socket):
     timeout = 2 + (randint(0, 10) / 10)
     plx.set_timeout(timeout)
 
-    assert plx.timeout == 2
+    assert plx.timeout == timeout

--- a/tests/support/mock_socket.py
+++ b/tests/support/mock_socket.py
@@ -9,6 +9,8 @@ class MockSocket:
         self.out_buffer = []
         self.in_buffer = []
 
+        self.timeout = None
+
     def connect(self, addr):
         if addr == (self.host, self.port):
             self.connected = True
@@ -24,3 +26,6 @@ class MockSocket:
     def recv(self, byte_num):
         value = self.in_buffer.pop()
         return value.encode('ascii')
+
+    def settimeout(self, timeout):
+        self.timeout = timeout


### PR DESCRIPTION
Useful for tuning control scripts to take less time to run. Some instruments and commands need longer timeouts and it's useful to not have to have the timeout set to the maximum required for everything.